### PR TITLE
Move Graphics with Command + LeftClick on Mac OS X

### DIFF
--- a/src/dfEditor/GraphicPanel.java
+++ b/src/dfEditor/GraphicPanel.java
@@ -810,6 +810,12 @@ public class GraphicPanel extends javax.swing.JDesktopPane implements MouseMotio
 
             case SELECT_BUTTON:
             {
+                if (System.getProperty("os.name").startsWith("Mac OS X") &&
+                        (evt.getModifiers() & ActionEvent.META_MASK) != 0)
+                {
+                    moveContent(dist, _lastOrigin);
+                    break;
+                }
                 if (!_bAllowsEditing)
                     break;
                 
@@ -874,6 +880,10 @@ public class GraphicPanel extends javax.swing.JDesktopPane implements MouseMotio
                     if (_movingGraphic == null || !_movingGraphic.isSelected())
                         unselectAllGraphics();
                 }
+                
+                if (System.getProperty("os.name").startsWith("Mac OS X") &&
+                        (evt.getModifiers() & ActionEvent.META_MASK) != 0)
+                    setCursor(Cursor.HAND_CURSOR);
                 
                 if (_movingGraphic != null)
                 {


### PR DESCRIPTION
As many MacBook users do Right-Click by "Clicking or tapping with two fingers" on their Trackpad, it becomes very hard to move some graphic content in the application. This pull request enables Mac users to use the `Command ⌘` modifier while left-clicking to drag graphic content.
