### PR TITLE
Ui

### DIFF
--- a/src/dfEditor/SpriteImagePanel.java
+++ b/src/dfEditor/SpriteImagePanel.java
@@ -48,7 +48,7 @@ public class SpriteImagePanel extends GraphicPanel
     {
         super.draw(g);
 
-        this.drawCheckerBoardBuffer(g, convertRectToViewRect(_graphicBounds));        
+        this.drawCheckerBoard(g, convertRectToViewRect(_graphicBounds));
     }
     
     @Override

--- a/src/dfEditor/SpritesheetPanel.java
+++ b/src/dfEditor/SpritesheetPanel.java
@@ -61,7 +61,7 @@ public class SpritesheetPanel extends GraphicPanel
             Point origin = getOrigin();
             Rectangle r = new Rectangle(origin.x, origin.y, actualSize.x, actualSize.y);
           
-            this.drawCheckerBoardBuffer(g, r);
+            this.drawCheckerBoard(g, r);
            
             g.drawImage(_pix.getImage(), r.x, r.y, r.width, r.height, this);
         }

--- a/src/dfEditor/SpritesheetPanel.java
+++ b/src/dfEditor/SpritesheetPanel.java
@@ -52,7 +52,7 @@ public class SpritesheetPanel extends GraphicPanel
 
     @Override
     protected void draw(Graphics g)
-    {          
+    {
         super.draw(g);
         
         if (_pix != null)
@@ -63,7 +63,7 @@ public class SpritesheetPanel extends GraphicPanel
           
             this.drawCheckerBoardBuffer(g, r);
            
-            g.drawImage(_pix.getImage(), r.x, r.y, r.width, r.height, this);            
+            g.drawImage(_pix.getImage(), r.x, r.y, r.width, r.height, this);
         }
     }
 
@@ -94,26 +94,6 @@ public class SpritesheetPanel extends GraphicPanel
         setGraphicsBounds(new Rectangle(0, 0, aImage.getWidth(), aImage.getHeight()));        
 
         _pix = new PixelBuffer(aImage);
-    }
-
-    @Override
-    public void setZoom(float aZoom)
-    {
-        if (_pix == null)
-        {
-            super.setZoom(aZoom);
-            return;
-        }
-        
-        Point oldImgSize = actualImageSize();
-        super.setZoom(aZoom);
-        Point imgSize = actualImageSize();
-
-        int xDiff = imgSize.x - oldImgSize.x;
-        int yDiff = imgSize.y - oldImgSize.y;
-
-        getOrigin().x -= xDiff >> 1;
-        getOrigin().y -= yDiff >> 1;
     }
 
     public Rectangle suggestVisibleSpriteRect()
@@ -223,8 +203,6 @@ public class SpritesheetPanel extends GraphicPanel
                 new Point(_pix.getImage().getWidth(), _pix.getImage().getHeight()),
                 getZoom() );         
     }   
-
-    
 
     @Override
     public void mouseClicked(MouseEvent e)

--- a/src/dfEditor/animation/AnimationStripPanel.java
+++ b/src/dfEditor/animation/AnimationStripPanel.java
@@ -46,11 +46,16 @@ import dfEditor.MathUtil;
  * @author s4m20
  */
 public class AnimationStripPanel extends javax.swing.JPanel implements AnimationDataListener, MouseMotionListener, MouseListener, ActionListener
-{   
+{
+    // the distance in pixels an animation cell needs to be dragged to count as dragging
+    private static final int MOUSE_DRAG_THRESHOLD = 10;
+    
     private Animation animation = null;
     private ArrayList<Slot> slotList = null;
     private AnimationController controller = null;
     private Point mousePoint = null;
+    private Point mousePressedPoint = null;
+    private boolean dragging = false;
     private int insertBeforeSlotIndex = -1;
     private Timer timer = null;
     private int currentSlotInAnimation = -1;
@@ -446,6 +451,13 @@ public class AnimationStripPanel extends javax.swing.JPanel implements Animation
         Point p = evt.getPoint();
 
         mousePoint = p;
+        
+        if (!dragging && (Math.abs(p.x - mousePressedPoint.x) <= MOUSE_DRAG_THRESHOLD))
+        {
+            return;
+        }
+        
+        dragging = true;
 
         int xOffset = 0;
 
@@ -490,6 +502,7 @@ public class AnimationStripPanel extends javax.swing.JPanel implements Animation
     public void mousePressed(MouseEvent evt)
     {
         Point p = evt.getPoint();
+        mousePressedPoint = p;
         controller.stripIndexSelected(-1);
 
         boolean selectedSlot = false;
@@ -551,7 +564,8 @@ public class AnimationStripPanel extends javax.swing.JPanel implements Animation
         if (orderChanged && insertBeforeSlotIndex < slotList.size())
                 slotList.get(insertBeforeSlotIndex).setSelected(true);
 
-        insertBeforeSlotIndex = -1;        
+        insertBeforeSlotIndex = -1;
+        dragging = false;
     }
 
     public void mouseExited(MouseEvent evt)
@@ -572,7 +586,7 @@ public class AnimationStripPanel extends javax.swing.JPanel implements Animation
     // just a dumb object really... could have come up with an elaborate
     // design for this whole strip class but just got it working... can always
     // revisit!
-    private class Slot
+    private static class Slot
     {
         static final int MARGIN = 3;
 


### PR DESCRIPTION
this PR improves a couple of things about the UI:
- If you move your mouse one pixel between mouse down and mouse up when clicking on an animation cell, it counts as dragging the cell. This happens very often on accident (at least to me). I've added a threshold of 10 pixels that you need to move at least to make it count as dragging.
- Change the mouse wheel zoom behaviour to zoom towards the cursor instead of the origin of the image.
- Change the way the checkerboard background is drawn. The new method only requires a tiny 2x2 BufferedImage that is used with appropriate tiling to draw the entire checkerboard in one simple fill command. This is requires less code and memory, and should also be more efficient because it's cache friendlier.
